### PR TITLE
DM-18848: Fix lsstdoc author parsing on "and"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+dist: xenial
 python:
   # General Python matrix
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ language: python
 python:
   # General Python matrix
   - "3.5"
+  - "3.6"
 matrix:
   include:
     # Additional job that can also deploy to PyPI
-    - python: "3.6"
+    - python: "3.7"
       env: "PYPI_DEPLOY=true"
 install:
   - "pip install .[dev]"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Change Log
 ==================
 
 - Fixed a bug where the ``lsstdoc`` author parsing would split names like "Amanda."
+- Updated ``pytest`` to 4.4.0, ``pytest-flake8`` to 1.0.4, and ``pytest-cov`` to 2.6.1.
 
 0.3.4 (2018-12-06)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Change Log
 ##########
 
+0.3.5 (2019-04-02)
+==================
+
+- Fixed a bug where the ``lsstdoc`` author parsing would split names like "Amanda."
+
 0.3.4 (2018-12-06)
 ==================
 

--- a/lsstprojectmeta/tex/lsstdoc.py
+++ b/lsstprojectmeta/tex/lsstdoc.py
@@ -541,13 +541,10 @@ class LsstLatexDoc(object):
         authors = []
         for part in content.split(','):
             part = part.strip()
-            if 'and' in part:
-                for split_part in part.split('and'):
-                    split_part = split_part.strip()
-                    if len(split_part) > 0:
-                        authors.append(split_part)
-            else:
-                authors.append(part)
+            for split_part in part.split('and '):
+                split_part = split_part.strip()
+                if len(split_part) > 0:
+                    authors.append(split_part)
         self._authors = authors
 
     def _parse_abstract(self):

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,9 @@ setup(
     extras_require={
         'dev': [
             # Development/testing dependencies
-            'pytest==3.2.5',
-            'pytest-cov==2.5.0',
-            'pytest-flake8==0.9.1',
+            'pytest==4.4.0',
+            'pytest-cov==2.6.1',
+            'pytest-flake8==1.0.4',
         ]},
     setup_requires=[
         'setuptools-scm==1.15.6',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,9 @@ setup(
         'pybtex>=0.21',
         'GitPython>=2.1.7',
         'pytz',
-        'motor>=1.2.0, <1.3.0'
+        'motor>=1.2.0, <1.3.0',
+        # https://github.com/Julian/jsonschema/issues/449#issuecomment-411406525
+        'attrs>=17.4.0 '
     ],
     extras_require={
         'dev': [

--- a/tests/test_lsstdoc.py
+++ b/tests/test_lsstdoc.py
@@ -35,6 +35,30 @@ def test_author_variations():
                                "Frossie Economou"]
 
 
+def test_author_list_amanda():
+    """Test author list parsing where one author's name is Amanda.
+    """
+    input_txt = (
+        r"\author   {William O'Mullane, John Swinbank, Leanne Guy, "
+        r"Amanda Bauer}"
+    )
+    expected = [
+        "William O'Mullane",
+        "John Swinbank",
+        "Leanne Guy",
+        "Amanda Bauer"
+    ]
+    lsstdoc = LsstLatexDoc(input_txt)
+    assert lsstdoc.authors == expected
+
+
+def test_author_list_and():
+    input_txt = r"\author{A.~Author, B.~Author, and C.~Author}"
+    expected = ['A. Author', 'B. Author', 'C. Author']
+    lsstdoc = LsstLatexDoc(input_txt)
+    assert lsstdoc.authors == expected
+
+
 def test_handle_variations():
     """Test variations on the handle command's formatting."""
     input_txt = r"\setDocRef      {LDM-503} % the reference code "


### PR DESCRIPTION
Fixed a bug where the ``lsstdoc`` author parsing would split names like "Amanda."